### PR TITLE
Generate order history model

### DIFF
--- a/app/models/order_history.rb
+++ b/app/models/order_history.rb
@@ -1,0 +1,29 @@
+class OrderHistory < ApplicationRecord
+	has_many :order_products
+	belongs_to :user
+
+	enum payment_option: {
+		bank_transfer: 1,
+		credit_card: 2
+	}
+
+	enum order_status: {
+		unpaied: 1,
+		payed: 2,
+		working: 3,
+		ready: 4,
+		shipped: 5
+	}
+
+	with_options presence: true do
+		validates :user_id
+		validates :addressee
+		validates :postal_code
+		validates :address
+		validates :payment_option
+		validates :order_status
+		validates :postage
+		validates :billing
+	end
+	add_index :order_histories, :user_id
+end

--- a/app/models/order_history.rb
+++ b/app/models/order_history.rb
@@ -8,8 +8,8 @@ class OrderHistory < ApplicationRecord
 	}
 
 	enum order_status: {
-		unpaied: 1,
-		payed: 2,
+		unpaid: 1,
+		paid: 2,
 		working: 3,
 		ready: 4,
 		shipped: 5
@@ -25,5 +25,4 @@ class OrderHistory < ApplicationRecord
 		validates :postage
 		validates :billing
 	end
-	add_index :order_histories, :user_id
 end

--- a/db/migrate/20200430133321_create_order_histories.rb
+++ b/db/migrate/20200430133321_create_order_histories.rb
@@ -1,0 +1,16 @@
+class CreateOrderHistories < ActiveRecord::Migration[5.2]
+  def change
+    create_table :order_histories do |t|
+      t.integer :user_id
+      t.string :addressee
+      t.string :postal_code
+      t.text :address
+      t.integer :payment_option, default: 1
+      t.integer :order_status, default: 1
+      t.integer :postage, default: 800
+      t.integer :billing
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20200430133321_create_order_histories.rb
+++ b/db/migrate/20200430133321_create_order_histories.rb
@@ -5,12 +5,13 @@ class CreateOrderHistories < ActiveRecord::Migration[5.2]
       t.string :addressee
       t.string :postal_code
       t.text :address
-      t.integer :payment_option, default: 1
+      t.integer :payment_option
       t.integer :order_status, default: 1
       t.integer :postage, default: 800
       t.integer :billing
 
       t.timestamps
     end
+	add_index :order_histories, :user_id
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -36,12 +36,13 @@ ActiveRecord::Schema.define(version: 2020_04_30_133321) do
     t.string "addressee"
     t.string "postal_code"
     t.text "address"
-    t.integer "payment_option", default: 1
+    t.integer "payment_option"
     t.integer "order_status", default: 1
     t.integer "postage", default: 800
     t.integer "billing"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_order_histories_on_user_id"
   end
 
   create_table "products", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_30_121712) do
+ActiveRecord::Schema.define(version: 2020_04_30_133321) do
 
   create_table "admin_users", force: :cascade do |t|
     t.string "email", default: "", null: false
@@ -24,6 +24,26 @@ ActiveRecord::Schema.define(version: 2020_04_30_121712) do
     t.index ["reset_password_token"], name: "index_admin_users_on_reset_password_token", unique: true
   end
 
+  create_table "genres", force: :cascade do |t|
+    t.string "name"
+    t.boolean "validation", default: true
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "order_histories", force: :cascade do |t|
+    t.integer "user_id"
+    t.string "addressee"
+    t.string "postal_code"
+    t.text "address"
+    t.integer "payment_option", default: 1
+    t.integer "order_status", default: 1
+    t.integer "postage", default: 800
+    t.integer "billing"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
   create_table "products", force: :cascade do |t|
     t.integer "genre_id"
     t.string "name"
@@ -31,13 +51,6 @@ ActiveRecord::Schema.define(version: 2020_04_30_121712) do
     t.integer "price"
     t.string "image_id"
     t.boolean "validation"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-  end
-
-  create_table "genres", force: :cascade do |t|
-    t.string "name"
-    t.boolean "validation", default: true
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end

--- a/test/fixtures/order_histories.yml
+++ b/test/fixtures/order_histories.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/models/order_history_test.rb
+++ b/test/models/order_history_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class OrderHistoryTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
#注文履歴モデルの編集
-payment_optionカラムのdefaults削除
-add_indexをモデルからマイグレーションファイルに移動
-order_status,enumの1,2をunpaid,paidに修正