### PR TITLE
admin/orders#showページを作成

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -15,3 +15,8 @@
  */
 @import "bootstrap-sprockets";
 @import "bootstrap";
+
+
+.table-noborder>tbody>tr>td{
+  border-style: none;
+}

--- a/app/controllers/admin/orders_controller.rb
+++ b/app/controllers/admin/orders_controller.rb
@@ -1,14 +1,62 @@
 class Admin::OrdersController < ApplicationController
+
+  include ApplicationHelper
+
   def index
     @order_histories = OrderHistory.page(params[:page]).per(10)
   end
 
   def show
+    @order_history = OrderHistory.find(params[:order_history_id])
+    @ordered_products = @order_history.ordered_products
   end
 
   def order_update
+    @order_history = OrderHistory.find(params[:order_history_id])
+    if @order_history.update( params_int(order_history_params) )
+      #このupdateにより製作ステータスを変更する必要が無いか確認し、必要があれば変更・保存。
+      #auto_update_work_statusはorder_history.rbに定義しています。
+      @order_history.auto_update_work_status
+      redirect_to "/admin/orders/#{@order_history.id}", success: "注文ステータスの更新が完了しました。"
+    else
+      @ordered_products = @order_history.ordered_products
+      render action: :show, danger: "注文ステータスの更新に失敗しました。"
+    end
   end
 
   def work_update
+    @ordered_product = OrderedProduct.find(params[:ordered_product_id])
+    @order_history = OrderHistory.find(@ordered_product.order_history.id)
+    if @ordered_product.update( params_int(ordered_product_params) )
+      #このupdateにより注文ステータスを変更する必要が無いか確認し、必要があれば変更・保存。
+      #auto_update_order_statusはordered_product.rbに定義しています。
+      @ordered_product.auto_update_order_status
+      redirect_to "/admin/orders/#{@order_history.id}", success: "制作ステータスの更新が完了しました。"
+    else
+      @ordered_products = @order_history.ordered_products
+      render action: :show, danger: "制作ステータスの更新に失敗しました。"
+    end
+  end
+
+  private
+
+  #integerで渡してもparamsではstringになってしまう。
+  def order_history_params
+    params.require(:order_history).permit(:order_status)
+  end
+
+  def ordered_product_params
+    params.require(:ordered_product).permit(:work_status)
+  end
+
+  #数値に変換可能なparamsをintegerに変換してくれる
+  def params_int(model_params)
+    model_params.each do |key, value|
+      #数値に変換可能かを確認(application_helper.rbに定義してあります。)
+      if integer_string?(value)
+        #数値に変換
+        model_params[key]=value.to_i
+      end
+    end
   end
 end

--- a/app/helpers/admin/orders_helper.rb
+++ b/app/helpers/admin/orders_helper.rb
@@ -1,2 +1,6 @@
 module Admin::OrdersHelper
+
+  def amount(order_products)
+    order_products.map{ |op| op.subtotal }.sum
+  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,17 @@
 module ApplicationHelper
+
+  # .roundで小数第一位を四捨五入。さらにinteger型に変換。
+  # .to_s(:delimited)で3桁のカンマ区切り。
+  def money_notation(price)
+    price.round.to_s(:delimited)
+  end
+
+  #値がintegerに変更可能かの確認
+  def integer_string?(str)
+    Integer(str)
+      true
+    rescue ArgumentError
+      false
+  end
+
 end

--- a/app/models/order_history.rb
+++ b/app/models/order_history.rb
@@ -25,4 +25,13 @@ class OrderHistory < ApplicationRecord
 		oh.validates :postage
 		oh.validates :billing
 	end
+
+	def auto_update_work_status
+		#注文ステータスが「入金確認」になったら注文商品の製作ステータスを全て「製作待ち」に。
+		if self.order_status_before_type_cast == 2
+			self.ordered_products.each do |op|
+				op.update(work_status: 2)
+			end
+		end
+	end
 end

--- a/app/models/ordered_product.rb
+++ b/app/models/ordered_product.rb
@@ -2,7 +2,7 @@ class OrderedProduct < ApplicationRecord
     belongs_to :product
     belongs_to :order_history
 
-    enum genre:{
+    enum work_status:{
         disable: 1,
         wait: 2,
         working: 3,
@@ -15,6 +15,24 @@ class OrderedProduct < ApplicationRecord
         op.validates :price
         op.validates :quantity
         op.validates :work_status
+    end
+
+    def subtotal
+        self.quantity * self.price
+    end
+
+    #ここはかなり見づらくなってしまいました。すみません。
+    def auto_update_order_status
+        parent_order_history = self.order_history
+        brothers_ordered_products = parent_order_history.ordered_products
+        brothers_work_statuses = brothers_ordered_products.map{ |op| op.work_status_before_type_cast }
+        #所属する注文履歴に紐づく注文商品の製作ステータスに1つでも「製作中」が有れば親注文履歴の注文ステータスを「製作中」に。
+        if  brothers_work_statuses.include?(3)
+            parent_order_history.update(order_status: 3)
+        #所属する注文履歴に紐づく注文商品の製作ステータスが全て「製作完了」なら親注文履歴の注文ステータスを「発送準備中」に。
+        elsif brothers_work_statuses.all?{ |ws| ws == 4 }
+            parent_order_history.update(order_status: 4)
+        end
     end
 
 end

--- a/app/views/admin/orders/show.html.erb
+++ b/app/views/admin/orders/show.html.erb
@@ -1,2 +1,131 @@
-<h1>Admin::Orders#show</h1>
-<p>Find me in app/views/admin/orders/show.html.erb</p>
+<div class="container">
+  <%# 見出し %>
+  <div class="row">
+    <div class="page-header">
+      <h1>注文履歴詳細</h1>
+    </div>
+  </div>
+
+  <%# 注文履歴詳細内容 %>
+  <div class="row">
+    <div class="col-xs-8">
+      <table class="table table-noborder">
+        <%# 購入者情報表示行 %>
+        <tr>
+          <td><b>購入者</b></td>
+          <td><%= link_to "#{@order_history.user.last_name}　#{@order_history.user.first_name}", admin_user_path(@order_history.user.id) %></td>
+        </tr>
+
+        <%# 配送先情報表示行 %>
+        <tr>
+          <td><b>配送先</b></td>
+          <td>
+          <p><%= "〒#{@order_history.postal_code} #{@order_history.address}" %></p>
+          <p><%= @order_history.addressee %></p>
+          </td>
+        </tr>
+
+        <%# 支払い方法表示行 %>
+        <tr>
+          <td><b>支払い方法</b></td>
+          <td>
+          <%= @order_history.payment_option_before_type_cast == 1 ? "銀行振込" : "クレジットカード" %>
+          </td>
+        </tr>
+
+        <%# 注文ステータス表示・更新行 %>
+        <tr>
+          <td><b>注文ステータス</b></td>
+          <td>
+            <%= form_for(@order_history, url: "/admin/orders/#{@order_history.id}/order_update") do |f| %>
+              <%# f.select内で使用するために定義 %>
+              <% order_statuses = {"入金待ち": 1, "入金確認": 2, "製作中": 3, "発送準備中": 4, "発送済み": 5} %>
+              <%# 初期値はorder_statusカラムの数値に対応したものに。 %>
+              <%= f.select :order_status, options_for_select(
+                order_statuses.map{ |key, value| [key, value]},
+                @order_history.order_status_before_type_cast
+              )%>
+              <%= f.submit "更新", class: "btn btn-primary"%>
+            <% end %>
+          </td>
+        </tr>
+
+      </table>
+    </div>
+  </div>
+
+  <%# 注文商品一覧テープル %>
+  <div class="row">
+    <div class="col-xs-8 table-responsive">
+      <table class="table">
+        <tr class="active">
+          <th>商品名</th>
+          <th>単価(税込み)</th>
+          <th>数量</th>
+          <th>小計</th>
+          <th>制作ステータス</th>
+        <tr>
+        <% @ordered_products.each do |op| %>
+          <tr>
+            <%# 商品名を表示 %>
+            <%# strftimeは時間を自分の好みの表記にできるヘルパー %>
+            <td><%= op.product.name %></td>
+
+            <%# 単価(姓込みを表示) %>
+            <%# money_notationはapplication_helper.rbに定義しました。 %>
+            <td><%= money_notation(op.price * 1.1) %></td>
+
+            <%# 注文数量を表示 %>
+            <td><%= op.quantity %></td>
+
+            <%# 商品小計を表示 %>
+            <%# .subtotalはordered_product.rbに定義しました %>
+            <td><%= money_notation(op.subtotal * 1.1) %></td>
+            <%# 制作ステータスの更新フォーム %>
+            <td>
+              <%= form_for(op, url: "/admin/orders/#{op.id}") do |f| %>
+                <%# f.select内で使うために定義 %>
+                <% work_statuses = { "着手不可": 1, "製作待ち": 2, "製作中": 3, "製作完了": 4 } %>
+                <%# 初期値はwork_statusカラムの数値に対応したものに。 %>
+                <%= f.select :work_status, options_for_select(
+                  work_statuses.map{ |key, value| [key, value] },
+                  op.work_status_before_type_cast
+                )%>
+                <%= f.submit "更新", class: "btn btn-primary"%>
+              <% end %>
+            </td>
+          <tr>
+        <% end %>
+      </table>
+    </div>
+
+    <%# 商品合計、送料、請求金額合計表示欄 %>
+    <div class="col-xs-4">
+      <table class="table table-noborder">
+        <tr>
+          <td><b>商品合計</b></td>
+          <%# amount()はordered_productsに定義しました。 %>
+          <td><%= money_notation( amount(@ordered_products) * 1.1 ) %>円</td>
+        </tr>
+        <tr>
+          <td><b>送料</b></td>
+          <td><%= @order_history.postage %>円</td>
+        </tr>
+        <tr>
+          <td><b>請求金額合計</b></td>
+          <td>
+          <%# 念のため算出した料金と請求金額カラムの値が等しいかどうかを確認し、違う場合は異常を知らせる %>
+          <% if @order_history.billing == amount(@ordered_products) * 1.1 + @order_history.postage %>
+            <%= @order_history.billing %>円
+          <% else %>
+            <%= @order_history.billing %>円
+            料金に異常があります。
+            お店へお問い合わせください。
+          <% end %>
+          </td>
+        </tr>
+      </table>
+    </div>
+  </div>
+
+</div>


### PR DESCRIPTION
○admin/orders#showページを作成。
○一部モデル・ヘルパーにメソッドを記載。

○注文ステータスと製作ステータスの関連を実装
・紐づく注文ステータスが「入金確認」になったら、関連する注文商品の製作ステータスが自動的に全て「製作待ち」になる処理を実装。
・紐づく注文商品の製作ステータスが一つでも「製作中」になったら、親注文履歴の注文ステータスが自動的に「製作中」になる処理を実装。
・紐づく注文商品の製作ステータスが全て「製作完了」になったら、親注文履歴の注文ステータスが自動的に「発送準備中」になる処理を実装。

○テーブルの枠線を消すCSSを記述。