### PR TITLE
close #81 admin/orders#indexが遷移元のページによって表示を変えるよう修正

### DIFF
--- a/app/controllers/admin/orders_controller.rb
+++ b/app/controllers/admin/orders_controller.rb
@@ -2,7 +2,7 @@ class Admin::OrdersController < ApplicationController
   def index
     #ページネーションで飛んできた時は@pathをparams[:prev_path]から取り、他のページから遷移してきた時はrequest.refererから@pathを取得。
     #params[:prev_path]がハッシュだからなのか、普通に@path = params[:prev_path]とするとunpermitted_paramsとしてエラーが出る。ひとまず.permit!を付けて解決。
-    params[:prev_path].exists? ? @path = params[:prev_path].permit! : @path = Rails.application.routes.recognize_path(request.referer)
+    params[:prev_path].nil? ? @path = Rails.application.routes.recognize_path(request.referer) : @path = params[:prev_path].permit!
 
     #@pathの中身で遷移元のページを判断
     if @path[:controller] == "admin/users"

--- a/app/controllers/admin/orders_controller.rb
+++ b/app/controllers/admin/orders_controller.rb
@@ -1,16 +1,23 @@
 class Admin::OrdersController < ApplicationController
   def index
-    params[:prev_path] ? @path = params[:prev_path].permit! : @path = Rails.application.routes.recognize_path(request.referer)
+    #ページネーションで飛んできた時は@pathをparams[:prev_path]から取り、他のページから遷移してきた時はrequest.refererから@pathを取得。
+    #params[:prev_path]がハッシュだからなのか、普通に@path = params[:prev_path]とするとunpermitted_paramsとしてエラーが出る。ひとまず.permit!を付けて解決。
+    params[:prev_path].exists? ? @path = params[:prev_path].permit! : @path = Rails.application.routes.recognize_path(request.referer)
+
+    #@pathの中身で遷移元のページを判断
     if @path[:controller] == "admin/users"
       case @path[:action]
         when "top"
-          #最初の表示は行けるが、ページネーションで他のページに行くとエラーが出る。
+          #.all_dayでその日の始めから終わりまで、という検索ができるとのこと。
+          #order(created_at: "DESC")で日付降順に
           @order_histories = OrderHistory.where(created_at: Time.zone.today.all_day).order(created_at: "DESC").page(params[:page]).per(10)
         when "show"
+          #ページネーションで飛んできた時はparams[:user_id]から以前のuser_idを使い回す。
           @user_id = params[:user_id]
           @order_histories = OrderHistory.where(user_id: params[:user_id]).order(created_at: "DESC").page(params[:page]).per(10)
       end
     else
+      #ヘッダーから飛んできた場合の処理に該当。全ての履歴を取ってくる。
       @order_histories = OrderHistory.order(created_at: "DESC").page(params[:page]).per(10)
     end
   end

--- a/app/controllers/admin/orders_controller.rb
+++ b/app/controllers/admin/orders_controller.rb
@@ -1,6 +1,18 @@
 class Admin::OrdersController < ApplicationController
   def index
-    @order_histories = OrderHistory.page(params[:page]).per(10)
+    params[:prev_path] ? @path = params[:prev_path].permit! : @path = Rails.application.routes.recognize_path(request.referer)
+    if @path[:controller] == "admin/users"
+      case @path[:action]
+        when "top"
+          #最初の表示は行けるが、ページネーションで他のページに行くとエラーが出る。
+          @order_histories = OrderHistory.where(created_at: Time.zone.today.all_day).order(created_at: "DESC").page(params[:page]).per(10)
+        when "show"
+          @user_id = params[:user_id]
+          @order_histories = OrderHistory.where(user_id: params[:user_id]).order(created_at: "DESC").page(params[:page]).per(10)
+      end
+    else
+      @order_histories = OrderHistory.order(created_at: "DESC").page(params[:page]).per(10)
+    end
   end
 
   def show

--- a/app/views/admin/orders/index.html.erb
+++ b/app/views/admin/orders/index.html.erb
@@ -49,7 +49,7 @@
       <%# kaminariのページング記述 %>
   <div class="row">
     <div class="col-xs-8 col-xs-offset-2">
-      <%= paginate @order_histories %>
+      <%= paginate @order_histories, params: { prev_path: @path, user_id: @user_id} %>
     </div>
   </div>
 

--- a/app/views/admin/orders/index.html.erb
+++ b/app/views/admin/orders/index.html.erb
@@ -49,6 +49,7 @@
       <%# kaminariのページング記述 %>
   <div class="row">
     <div class="col-xs-8 col-xs-offset-2">
+      <%# ページネーションのページ遷移の際にparamsを渡して、以前のページの情報を使い回す %>
       <%= paginate @order_histories, params: { prev_path: @path, user_id: @user_id} %>
     </div>
   </div>

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -45,7 +45,7 @@
     <div class='row'>
         <%= link_to '編集する', edit_admin_user_path(@users.id), class: 'btn btn-default' %>
 
-        <%= link_to '注文履歴一覧', admin_orders_path, class: 'btn btn-default' %>
+        <%= link_to '注文履歴一覧', admin_orders_path(user_id: @users.id), class: 'btn btn-default' %>
     </div>
 
 </div>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -78,7 +78,7 @@ end
   first_name = first_names[first_name_random]
   last_name = last_names[last_name_random]
 
-  addressee = last_name + first_name
+  addressee = "#{last_name}　#{first_name}"
   postal_code = Faker::Address.postcode.to_s
   address = Faker::Address.state + Faker::Address.city
 
@@ -157,6 +157,56 @@ end
   )
 end
 
+#動作確認用に最初のユーザーに履歴を30件追加
+30.times do |n|
+  user = User.find(1)
+  destination_random = rand(0..1)
+  destination = user.destinations[destination_random]
+
+  user_id = user.id
+  addressee = destination.addressee
+  postal_code = destination.postal_code
+  address = destination.address
+  payment_option = rand(1..2)
+  billing = 800
+
+  order_history = OrderHistory.create!(
+    user_id: user_id,
+    addressee: addressee,
+    postal_code: postal_code,
+    address: address,
+    payment_option: payment_option,
+    billing: billing
+  )
+
+  rand(1..3).times do |i|
+    product_id = rand(1..Product.all.length)
+    order_history_id = order_history.id
+    price = Product.find(product_id).price
+    quantity = rand(1..5)
+
+    OrderedProduct.create!(
+      product_id: product_id,
+      order_history_id: order_history_id,
+      price: price,
+      quantity: quantity
+    )
+  end
+
+  ordered_products = OrderedProduct.where(order_history_id: order_history.id)
+  billing = order_history.billing
+
+  ordered_products.each do |ordered_product|
+    billing +=  ordered_product.price * ordered_product.quantity  * 1.1
+  end
+
+  date = Faker::Date.between(from:2.month.ago, to: 2.month.from_now)
+  order_history.update!(
+    billing: billing,
+    created_at: date,
+    updated_at: date
+  )
+end
 
 # 7.cart_products
 # idが奇数のユーザーだけカート内に商品がある状態に


### PR DESCRIPTION
・orders_controllerで遷移元のページによって@order_historiesの中身を変えるよう記述。
(kaminariのページネーションにも対応)
・その際にadmin/user#showからパラメータを渡す必要があったため、link_toの記述に少し追加。
・動作確認のためにseeds.rbを修正。最初のユーザーに注文履歴を30件追加。
(ついでにdestinationsのaddresseeについて、姓と名の間にスペースが無かったのでスペースが入るように修正。)