### PR TITLE
【ゆう】管理サイト/商品詳細ページ作成

### DIFF
--- a/app/controllers/admin/products_controller.rb
+++ b/app/controllers/admin/products_controller.rb
@@ -16,6 +16,7 @@ class Admin::ProductsController < ApplicationController
   end
 
   def show
+    @product = Product.find(params[:id])
   end
 
   def update

--- a/app/views/admin/products/show.html.erb
+++ b/app/views/admin/products/show.html.erb
@@ -5,7 +5,7 @@
 
 	<div class="row">
 		<div class="col-xs-4">
-			<p>商品イメージ</p>
+			<%= attachment_image_tag @product, :image_id, :fill, 50, 50, format: "jpeg", fallback: "logo.png", size:'245x245' %>
 		</div>
 		<div class="col-xs-8">
 			<div class="table-responsive">
@@ -49,6 +49,12 @@
 					</tbody>
 				</table>
 			</div>
+		</div>
+	</div>
+
+	<div class="row">
+		<div class="text-right">
+			<%= link_to "編集", edit_admin_product_path(@product.id), class: "btn btn-primary" %>
 		</div>
 	</div>
 </div>

--- a/app/views/admin/products/show.html.erb
+++ b/app/views/admin/products/show.html.erb
@@ -1,2 +1,54 @@
-<h1>Admin::Products#show</h1>
-<p>Find me in app/views/admin/products/show.html.erb</p>
+<div class="container">
+	<div class="row">
+			<h1>商品詳細</h1>
+	</div>
+
+	<div class="row">
+		<div class="col-xs-4">
+			<p>商品イメージ</p>
+		</div>
+		<div class="col-xs-8">
+			<div class="table-responsive">
+				<table class="table text-nowrap">
+					<tbody>
+						<tr>
+							<td>商品名</td>
+							<td>
+								<%= @product.name %>
+							</td>
+						</tr>
+						<tr>
+							<td>商品説明</td>
+							<td>
+								<%= @product.introduction %>
+							</td>
+						</tr>
+						<tr>
+							<td>ジャンル</td>
+							<td>
+								<%= @product.genre.name %>
+							</td>
+						</tr>
+						<tr>
+							<td>税込価格（税別価格）</td>
+							<td>
+								<%= money_notation(@product.price*1.1) %>
+								(<%= @product.price %>)円
+							</td>
+						</tr>
+						<tr>
+							<td>販売ステータス</td>
+							<td>
+								<% if @product.validation == true %>
+									<%= "販売中" %>
+								<% else %>
+									<%= "売り切れ" %>
+								<% end %>
+							</td>
+						</tr>
+					</tbody>
+				</table>
+			</div>
+		</div>
+	</div>
+</div>

--- a/app/views/admin/products/show.html.erb
+++ b/app/views/admin/products/show.html.erb
@@ -33,16 +33,18 @@
 							<td>税込価格（税別価格）</td>
 							<td>
 								<%= money_notation(@product.price*1.1) %>
-								(<%= @product.price %>)円
+								<%# money_notatioの追加 %>
+								(<%= money_notation(@product.price) %>)円
 							</td>
 						</tr>
 						<tr>
 							<td>販売ステータス</td>
 							<td>
 								<% if @product.validation == true %>
-									<%= "販売中" %>
+									<%# tdで囲まれているため<%=>の削除 %>
+									販売中
 								<% else %>
-									<%= "売り切れ" %>
+									売り切れ
 								<% end %>
 							</td>
 						</tr>


### PR DESCRIPTION
#管理サイト/商品詳細ページの作成
-contorollers/admin/products#showの編集
-view/admin/products#showの編集
→商品説明が長くなる可能性を加味し、スクロールが出来るようtableをtable-responsiveで囲んでいます。
-編集ページへの画面遷移確認済みです。
