### PR TITLE
【ゆう】close #70 金額/詳細リンク先修正

### DIFF
--- a/app/views/public/orders/index.html.erb
+++ b/app/views/public/orders/index.html.erb
@@ -31,7 +31,7 @@
 								<% end %>
 							</td>
 							<td>
-								<%= order.billing %>円
+								<%= money_notation(order.billing*1.1) %>円
 							</td>
 							<td>
 								<% case order.order_status %>
@@ -45,10 +45,10 @@
 					                <%= "発送準備中" %>
 					            <% when "shipped" %>
 					                <%= "発送済み" %>
-					            <% end %>				
+					            <% end %>
 					        </td>
 							<td>
-								<%= link_to "表示する", order_path(current_user.id), class: "btn btn-primary btn-block" %>
+								<%= link_to "表示する", order_path(order.id), class: "btn btn-primary btn-block" %>
 							</td>
 						</tr>
 					<% end %>


### PR DESCRIPTION
#【ゆう】close #70  金額/詳細リンク先修正
-支払い金額に税率を掛け、money_notatioで金額表記を修正
-詳細ページのリンク先が引数が異なっていたため、該当ページに遷移するよう修正
