### PR TITLE
【とし】商品詳細ページ　顧客がログインしていないときに商品を買えずログイン画面へ遷移させる #83

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,10 +8,5 @@ class ApplicationController < ActionController::Base
   def configure_permitted_parameters
     devise_parameter_sanitizer.permit(:sign_up, keys: [:first_name, :last_name, :kana_first_name, :kana_last_name, :postal_code, :address, :phone_number])
   end
-  #フレンドリーフォワーディングの実装
-  def store_current_location
-    return if current_user
-    store_location_for(:user, request.url)
-  end
 
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,12 +1,17 @@
 class ApplicationController < ActionController::Base
   before_action :configure_permitted_parameters, if: :devise_controller?
-
+  before_action :store_current_location, unless: :devise_controller?
   add_flash_types :success, :info, :warning, :danger
 
   protected
   #deviseのストロングパラメータ記述
   def configure_permitted_parameters
     devise_parameter_sanitizer.permit(:sign_up, keys: [:first_name, :last_name, :kana_first_name, :kana_last_name, :postal_code, :address, :phone_number])
+  end
+  #フレンドリーフォワーディングの実装
+  def store_current_location
+    return if current_user
+    store_location_for(:user, request.url)
   end
 
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,6 @@
 class ApplicationController < ActionController::Base
   before_action :configure_permitted_parameters, if: :devise_controller?
-  before_action :store_current_location, unless: :devise_controller?
+
   add_flash_types :success, :info, :warning, :danger
 
   protected

--- a/app/controllers/public/cart_products_controller.rb
+++ b/app/controllers/public/cart_products_controller.rb
@@ -1,4 +1,5 @@
 class Public::CartProductsController < ApplicationController
+  before_action :authenticate_user!, only: [:create] #device機能を利用した時に使えるやつ。オプションはonlyとexceptがある。
   def create
     @cart_product = CartProduct.new(cart_product_params)
     @cart_product.user_id = current_user.id

--- a/app/controllers/public/products_controller.rb
+++ b/app/controllers/public/products_controller.rb
@@ -6,7 +6,6 @@ class Public::ProductsController < ApplicationController
 
   def show
     @product = Product.find(params[:id])
-    # @cart_product = Cart_product.new キャメルケースを利用↓↓
-    @cart_product = CartProduct.new
+    @cart_product = CartProduct.new #Cart_product.new キャメルケースを利用
   end
 end


### PR DESCRIPTION
お疲れ様です。
商品詳細ページからカートに入れる際、顧客と会員で遷移をかえました。
顧客→強制的にログイン画面へ
会員→Public::CartProducts#index
よろしくお願いいたします。