### PR TITLE
【一刀】close #109　ヘッダーのロジックを修正。ついでにログイン後のページを設定

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -9,4 +9,13 @@ class ApplicationController < ActionController::Base
     devise_parameter_sanitizer.permit(:sign_up, keys: [:first_name, :last_name, :kana_first_name, :kana_last_name, :postal_code, :address, :phone_number])
   end
 
+  def after_sign_in_path_for(resource)
+    case resource
+    when User
+      root_path
+    when AdminUser
+      admin_path
+    end
+  end
+
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -19,41 +19,10 @@
         </nav>
         <nav>
           <ul class="nav nav-pills navbar-light navbar-right">
-            <% if user_signed_in? %>
+            <%# URLにadminが入っているかどうかでどちらのサイトなのかを判別 %>
+            <% if request.url.include?('admin') %>
+              <%# 管理者サイト かつ 管理人でログインしている場合 %>
               <% if admin_user_signed_in? %>
-                <li>
-                  ようこそ、<%= current_user.first_name %>さん！
-                </li>
-                <li>
-                  <%= link_to "マイページ", "/user", :style=>"color:black;" %>
-                </li>
-                <li>
-                  <%= link_to "商品一覧", products_path, :style=>"color:black;" %>
-                </li>
-                <li>
-                  <%= link_to "カート", cart_products_path, :style=>"color:black;" %>
-                </li>
-                <li>
-                  <%= link_to "ログアウト", destroy_user_session_path, method: :delete, :style=>"color:black;" %>
-                </li>
-              <% else %>
-                <li>
-                  ようこそ、<%= current_user.first_name %>さん！
-                </li>
-                <li>
-                  <%= link_to "マイページ", "/user", :style=>"color:black;" %>
-                </li>
-                <li>
-                  <%= link_to "商品一覧", products_path, :style=>"color:black;" %>
-                </li>
-                <li>
-                  <%= link_to "カート", cart_products_path, :style=>"color:black;" %>
-                </li>
-                <li>
-                  <%= link_to "ログアウト", destroy_user_session_path, method: :delete, :style=>"color:black;" %>
-                </li>
-              <% end %>
-            <% elsif admin_user_signed_in? %>
                 <li>
                   <%= link_to "商品一覧", admin_products_path, :style=>"color:black;" %>
                 </li>
@@ -69,7 +38,38 @@
                 <li>
                   <%= link_to "ログアウト", destroy_admin_user_session_path, method: :delete, :style=>"color:black;" %>
                 </li>
+
+              <%# 管理者サイト かつ 管理人でログインしていない場合 %>
               <% else %>
+                <li>
+                  <%= link_to "ECサイト：商品一覧", products_path, :style=>"color:black;" %>
+                </li>
+                <li>
+                  <%= link_to "ECサイト：新規登録", new_user_registration_path, :style=>"color:black;" %>
+                </li>
+                <li>
+                  <%= link_to "ECサイト：ログイン", new_user_session_path, :style=>"color:black;" %>
+                </li>
+              <% end %>
+            <%# ECサイト かつ 会員でログインしている場合 %>
+            <% elsif user_signed_in? %>
+                <li>
+                  ようこそ、<%= current_user.first_name %>さん！
+                </li>
+                <li>
+                  <%= link_to "マイページ", "/user", :style=>"color:black;" %>
+                </li>
+                <li>
+                  <%= link_to "商品一覧", products_path, :style=>"color:black;" %>
+                </li>
+                <li>
+                  <%= link_to "カート", cart_products_path, :style=>"color:black;" %>
+                </li>
+                <li>
+                  <%= link_to "ログアウト", destroy_user_session_path, method: :delete, :style=>"color:black;" %>
+                </li>
+            <%# ECサイト かつ 会員でログインしていない場合 %>
+            <% else %>
                 <li>
                   <%= link_to "商品一覧", products_path, :style=>"color:black;" %>
                 </li>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -14,7 +14,7 @@
       <div class="container">
         <nav class="nav navbar-light navbar-left">
           <%# ロゴのリンク先もECサイトと管理人サイトで分けます。%>
-          <% if request.url.include?('admin)' %>  <%# 今のURLに'admin'が入っているかどうかでどちらのサイトなのかを識別 %>
+          <% if request.url.include?('admin') %>  <%# 今のURLに'admin'が入っているかどうかでどちらのサイトなのかを識別 %>
             <%# 管理人サイトの場合 %>
             <a href="/admin" style="font-size: 40px">
               <%= image_tag 'header-logo.png', :size => '150x60' %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -13,13 +13,22 @@
     <header id="header" class="navbar navbar-light bg-light">
       <div class="container">
         <nav class="nav navbar-light navbar-left">
-          <a href="/" style="font-size: 40px">
-            <%= image_tag 'header-logo.png', :size => '150x60' %>
-          </a>
+          <%# ロゴのリンク先もECサイトと管理人サイトで分けます。%>
+          <% if request.url.include?('admin)' %>  <%# 今のURLに'admin'が入っているかどうかでどちらのサイトなのかを識別 %>
+            <%# 管理人サイトの場合 %>
+            <a href="/admin" style="font-size: 40px">
+              <%= image_tag 'header-logo.png', :size => '150x60' %>
+            </a>
+          <% else %>
+            <%# ECサイトの場合 %>
+            <a href="/" style="font-size: 40px">
+              <%= image_tag 'header-logo.png', :size => '150x60' %>
+            </a>
+          <% end %>
         </nav>
         <nav>
           <ul class="nav nav-pills navbar-light navbar-right">
-            <%# URLにadminが入っているかどうかでどちらのサイトなのかを判別 %>
+            <%# 今のURLにadminが入っているかどうかでどちらのサイトなのかを識別 %>
             <% if request.url.include?('admin') %>
               <%# 管理者サイト かつ 管理人でログインしている場合 %>
               <% if admin_user_signed_in? %>
@@ -39,7 +48,7 @@
                   <%= link_to "ログアウト", destroy_admin_user_session_path, method: :delete, :style=>"color:black;" %>
                 </li>
 
-              <%# 管理者サイト かつ 管理人でログインしていない場合 %>
+              <%# 管理者サイト かつ 管理人でログインしていない場合(adminのログイン画面のみ) %>
               <% else %>
                 <li>
                   <%= link_to "ECサイト：商品一覧", products_path, :style=>"color:black;" %>


### PR DESCRIPTION
・adminページにいるのかどうか + 各種ログインしているかどうかにロジックを修正。
・application_controller.rbでafter_sign_in_path_for(resource)をオーバーライド。
User、AdminUserのログインに応じて表示するページを分ける。