### PR TITLE
【一刀】 close #62 close #64 close #93　マイページの「パスワードを変更する」ボタンからの遷移を修正

### DIFF
--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
 class Users::PasswordsController < Devise::PasswordsController
+  #ログイン状態で:new, :createを実行するために必要。(デフォルトでは、ログインしていないことが求められている。)
+  #そして"Send me reset password instructions"を押すとエラーが出るが、原因はよくわからない。ひとまずこれでOKとしたいです。
+  prepend_before_action :require_no_authentication, except: [:new, :create]
+
   # GET /resource/password/new
   # def new
   #   super

--- a/app/views/public/users/show.html.erb
+++ b/app/views/public/users/show.html.erb
@@ -9,7 +9,9 @@
     </div>
     <div class="col-xs-6">
       <%= link_to "編集する", edit_user_path(current_user.id), class: "btn btn-primary" %>
-      <%= link_to "パスワードを変更する", edit_user_password_path(current_user.id), class: "btn btn-primary" %>
+      <%# edit_user_password_pathはパスワード再設定時の編集画面で、メールのリンク以外ではアクセスできない様なのでnew_user_password_pathに設定。%>
+      <%# UIフロー的にもそれでOKな様子。 %>
+      <%= link_to "パスワードを変更する", new_user_password_path, class: "btn btn-primary" %>
     </div>
   </div>
   <br>

--- a/app/views/public/users/show.html.erb
+++ b/app/views/public/users/show.html.erb
@@ -19,29 +19,29 @@
   <%# ユーザーの情報をテーブルで表示 %>
   <div class="row">
     <div class="col-xs-6">
-      <table class="table">
+      <table class="table table-bordered">
         <tr>
-          <td>氏名</td>
+          <td class="active">氏名</td>
           <td><%= "#{@user.last_name}　#{@user.first_name}" %></td>
         </tr>
         <tr>
-          <td>カナ</td>
+          <td class="active">カナ</td>
           <td><%= "#{@user.kana_last_name}　#{@user.kana_first_name}" %></td>
         </tr>
         <tr>
-          <td>郵便番号</td>
+          <td class="active">郵便番号</td>
           <td><%= @user.postal_code %></td>
         </tr>
         <tr>
-          <td>住所</td>
+          <td class="active">住所</td>
           <td><%= @user.address %></td>
         </tr>
         <tr>
-          <td>電話番号</td>
+          <td class="active">電話番号</td>
           <td><%= @user.phone_number %></td>
         </tr>
         <tr>
-          <td>メールアドレス</td>
+          <td class="active">メールアドレス</td>
           <td><%= @user.email %></td>
         </tr>
       </table>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -51,3 +51,68 @@ ja:
         email: メールアドレス
         password: パスワード
         password_confirmation: パスワード（確認用）
+  devise:
+    confirmations:
+      confirmed: 'アカウントを登録しました。'
+      send_instructions: 'アカウントの有効化について数分以内にメールでご連絡します。'
+      send_paranoid_instructions: "あなたのメールアドレスが登録済みの場合、本人確認用のメールが数分以内に送信されます。"
+    failure:
+      already_authenticated: 'すでにログインしています。'
+      inactive: 'アカウントが有効化されていません。メールに記載された手順にしたがって、アカウントを有効化してください。'
+      invalid: "%{authentication_keys} もしくはパスワードが不正です。"
+      locked: 'あなたのアカウントは凍結されています。'
+      last_attempt: 'あなたのアカウントが凍結される前に、複数回の操作がおこなわれています。'
+      not_found_in_database: "%{authentication_keys} もしくはパスワードが不正です。"
+      timeout: 'セッションがタイムアウトしました。もう一度ログインしてください。'
+      unauthenticated: 'アカウント登録もしくはログインしてください。'
+      unconfirmed: 'メールアドレスの本人確認が必要です。'
+    mailer:
+      confirmation_instructions:
+        subject: 'アカウントの有効化について'
+      reset_password_instructions:
+        subject: 'パスワードの再設定について'
+      unlock_instructions:
+        subject: 'アカウントの凍結解除について'
+      password_change:
+        subject: 'パスワードの変更について'
+    omniauth_callbacks:
+      failure: "%{kind} アカウントによる認証に失敗しました。理由：（%{reason}）"
+      success: "%{kind} アカウントによる認証に成功しました。"
+    passwords:
+      no_token: "このページにはアクセスできません。パスワード再設定メールのリンクからアクセスされた場合には、URL をご確認ください。"
+      send_instructions: 'パスワードの再設定について数分以内にメールでご連絡いたします。'
+      send_paranoid_instructions: "あなたのメールアドレスが登録済みの場合、パスワード再設定用のメールが数分以内に送信されます。"
+      updated: 'パスワードが正しく変更されました。'
+      updated_not_active: 'パスワードが正しく変更されました。'
+    registrations:
+      destroyed: 'アカウントを削除しました。またのご利用をお待ちしております。'
+      signed_up: 'アカウント登録が完了しました。'
+      signed_up_but_inactive: 'ログインするためには、アカウントを有効化してください。'
+      signed_up_but_locked: 'アカウントが凍結されているためログインできません。'
+      signed_up_but_unconfirmed: '本人確認用のメールを送信しました。メール内のリンクからアカウントを有効化させてください。'
+      update_needs_confirmation: 'アカウント情報を変更しました。変更されたメールアドレスの本人確認のため、本人確認用メールより確認処理をおこなってください。'
+      updated: 'アカウント情報を変更しました。'
+    sessions:
+      signed_in: 'ログインしました。'
+      signed_out: 'ログアウトしました。'
+      already_signed_out: '既にログアウト済みです。'
+    unlocks:
+      send_instructions: 'アカウントの凍結解除方法を数分以内にメールでご連絡します。'
+      send_paranoid_instructions: 'アカウントが見つかった場合、アカウントの凍結解除方法を数分以内にメールでご連絡します。'
+      unlocked: 'アカウントを凍結解除しました。'
+  errors:
+    messages:
+      already_confirmed: 'は既に登録済みです。ログインしてください。'
+      confirmation_period_expired: "の期限が切れました。%{period} までに確認する必要があります。 新しくリクエストしてください。"
+      expired: 'の有効期限が切れました。新しくリクエストしてください。'
+      not_found: 'は見つかりませんでした。'
+      not_locked: 'は凍結されていません。'
+      not_saved:
+        one: "エラーが発生したため %{resource} は保存されませんでした:"
+        other: "%{count} 件のエラーが発生したため %{resource} は保存されませんでした:"
+      taken: "は既に使用されています。"
+      blank: "が入力されていません。"
+      too_short: "は%{count}文字以上に設定して下さい。"
+      too_long: "は%{count}文字以下に設定して下さい。"
+      invalid: "は有効でありません。"
+      confirmation: "が内容とあっていません。"


### PR DESCRIPTION
・ログイン状態でも「パスワードを変更する」ボタンから、パスワードの再設定画面へ遷移するよう修正。
・ついでにdeviseのコメントも日本語化