### PR TITLE
【ゆう】close #124 会員注文履歴一覧/支払金額修正	

### DIFF
--- a/app/views/public/orders/index.html.erb
+++ b/app/views/public/orders/index.html.erb
@@ -31,7 +31,7 @@
 								<% end %>
 							</td>
 							<td>
-								<%= money_notation(order.billing*1.1) %>円
+								<%= money_notation(order.billing) %>円
 							</td>
 							<td>
 								<% case order.order_status %>

--- a/app/views/public/orders/show.html.erb
+++ b/app/views/public/orders/show.html.erb
@@ -99,7 +99,7 @@
 								<%= op.product.name %>
 							</td>
 							<td>
-								<%= money_notation(op.price*1.1) %>
+								<%= money_notation(op.price*1.1) %>円
 							</td>
 							<td>
 								<%= op.quantity %>


### PR DESCRIPTION
#【ゆう】close #124  会員注文履歴一覧/支払金額修正
-一覧と詳細で金額がズレるのは一覧の支払金額(billing)に消費税を掛けているせいでした
→"*1.1”を消去
