### PR TITLE
【一刀】close #112 退会ユーザーをログインできないように修正

### DIFF
--- a/app/controllers/public/users_controller.rb
+++ b/app/controllers/public/users_controller.rb
@@ -21,6 +21,11 @@ class Public::UsersController < ApplicationController
   end
 
   def destroy
+    user = current_user
+    user.update(validation: false)
+    #update後にログアウトしたい。
+    sign_out user
+    redirect_to root_path, success: "退会処理が完了しました。"
   end
 
   def cancel

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -9,9 +9,14 @@ class Users::SessionsController < Devise::SessionsController
   # end
 
   # POST /resource/sign_in
-  # def create
-  #   super
-  # end
+  def create
+    user = User.find_by(email: sign_in_params[:email])
+    if user.validation == false
+      redirect_to root_path, danger: "退会済みのユーザーです。"
+    else
+      super
+    end
+  end
 
   # DELETE /resource/sign_out
   # def destroy

--- a/app/views/public/users/cancel.html.erb
+++ b/app/views/public/users/cancel.html.erb
@@ -6,7 +6,7 @@
     <p>これまでの購入履歴が閲覧できなくなります。</p>
     <p>退会する場合は、「退会する」をクリックしてください。</p>
     <%= link_to '退会しない', user_path, class: "btn btn-primary " %>
-    <%= link_to '退会する', root_path, class: "btn btn-danger " %>
+    <%= link_to '退会する', user_path, method: :put, class: "btn btn-danger " %>
    </div>
   </div>
 </div>


### PR DESCRIPTION
・deviseのsession_controller.rbのcreateを編集。
validationがfalse(＝退会済み)の場合はトップページにリダイレクト
・併せて退会処理も実装。(users_controller.rbのdestroy)