### PR TITLE
【一刀】paginationのtruncateが消えるよう修正

### DIFF
--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -116,3 +116,10 @@ ja:
       too_long: "は%{count}文字以下に設定して下さい。"
       invalid: "は有効でありません。"
       confirmation: "が内容とあっていません。"
+  views:
+    pagination:
+      first: "<<"
+      last: ">>"
+      previous: "<"
+      next: ">"
+      truncate: "..."


### PR DESCRIPTION
以前エラー文を日本語化したことが原因でpaginationにtruncateという文字が表示されていた様子。ja.ymlに必要な記述を追加しました。