### PR TITLE
【一刀】注文履歴一覧がうまく表示されない場合があった不具合を修正

### DIFF
--- a/app/views/admin/orders/index.html.erb
+++ b/app/views/admin/orders/index.html.erb
@@ -50,7 +50,7 @@
   <div class="row">
     <div class="col-xs-8 col-xs-offset-2">
       <%# ページネーションのページ遷移の際にparamsを渡して、以前のページの情報を使い回す %>
-      <%= paginate @order_histories, params: { prev_path: @path, user_id: @user_id} %>
+      <%= paginate @order_histories, params: { prev_path: @prev_path, user_id: @user_id} %>
     </div>
   </div>
 

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -51,7 +51,7 @@
     <div class='row'>
         <%= link_to '編集する', edit_admin_user_path(@user.id), class: 'btn btn-default' %>
 
-        <%= link_to '注文履歴一覧', admin_orders_path(@user.id), class: 'btn btn-default' %>
+        <%= link_to '注文履歴一覧', admin_orders_path(user_id: @user.id), class: 'btn btn-default' %>
     </div>
 
 </div>


### PR DESCRIPTION
・admin/user#showから注文一覧を表示すると何故か一件も表示されていなかったので修正。
・ページネーションでエラーが出るようになってしまっていたので再度修正。