### PR TITLE
【一刀】attachment_image_tagのfillを削除

### DIFF
--- a/app/views/admin/products/edit.html.erb
+++ b/app/views/admin/products/edit.html.erb
@@ -6,7 +6,7 @@
   <div class="row">
     <%= form_for(@product,url: admin_product_path(@product.id)) do |f| %>    <%# urlを追加してみたけどerror%>
       <div class="col-xs-4">
-        <%= attachment_image_tag @product, :image, :fill, 400, 400,format: 'jpg', fallback: "logo.png", size:'245x245' %><%# defaultで画像を用意する%>　<%# 5/10formatを'jpg'、sizeを'245x245'に変更 %>
+        <%= attachment_image_tag @product, :image,format: 'jpg', fallback: "logo.png", size:'245x245' %><%# defaultで画像を用意する%>　<%# 5/10formatを'jpg'、sizeを'245x245'に変更 %>
         <%= f.attachment_field :image %>
       </div>
 

--- a/app/views/admin/products/show.html.erb
+++ b/app/views/admin/products/show.html.erb
@@ -5,7 +5,7 @@
 
 	<div class="row">
 		<div class="col-xs-4">
-			<%= attachment_image_tag @product, :image, :fill, 400, 400, format: "jpg", fallback: "logo.png", size:'245x245' %>
+			<%= attachment_image_tag @product, :image, format: "jpg", fallback: "logo.png", size:'245x245' %>
 			<%# 5/10fillを400,400にfromatを'jpg'に変更 %>
 		</div>
 		<div class="col-xs-8">

--- a/app/views/public/cart_products/index.html.erb
+++ b/app/views/public/cart_products/index.html.erb
@@ -25,7 +25,7 @@
                         <% @cart_products.each do |cart_product| %>
                             <tr>
                                 <td>
-                                    <%= attachment_image_tag cart_product.product, :image, :fill, 400, 400,format: 'jpg', fallback: "logo.png", size:'60x60' %>
+                                    <%= attachment_image_tag cart_product.product, :image,format: 'jpg', fallback: "logo.png", size:'60x60' %>
                                     <%= cart_product.product.name %>
                                 </td>
                                 <td class="text-right">

--- a/app/views/public/orders/confirmation.html.erb
+++ b/app/views/public/orders/confirmation.html.erb
@@ -21,7 +21,7 @@
                     <% @cart_products.each do |cart_product| %>
                         <tr>
                             <td  style="height:60px">
-                                <%= attachment_image_tag cart_product.product, :image, :fill, 400, 400, format: 'jpg', class: "pull-left profile-img", fallback: "logo.png", size:'40x40' %>
+                                <%= attachment_image_tag cart_product.product, :image, format: 'jpg', class: "pull-left profile-img", fallback: "logo.png", size:'40x40' %>
                                 <%= cart_product.product.name %>
                             </td>
                             <td><%= money_notation((cart_product.product.price * 1.1)) %>円</td>

--- a/app/views/public/products/index.html.erb
+++ b/app/views/public/products/index.html.erb
@@ -9,7 +9,7 @@
       <div>
         <%= link_to product_path(product.id) do %>
         <%# 5/10 @productの@を削除,fill:400,size:150に変更 %>
-        <%= attachment_image_tag product, :image, :fill, 400, 400, format: 'jpeg', fallback: "logo.png", size: 150 %><br>
+        <%= attachment_image_tag product, :image, format: 'jpeg', fallback: "logo.png", size: 150 %><br>
         <% end %>
         <%= product.name %><br>
         <%= product.price %>円<br>

--- a/app/views/public/products/show.html.erb
+++ b/app/views/public/products/show.html.erb
@@ -2,7 +2,7 @@
   <div class="row">
     <div class="col-xs-4 ">
       <%# 5/10 fill:400,format:jpg,size:245に変更 %>
-      <%= attachment_image_tag @product, :image, :fill, 400, 400, format: 'jpg', fallback: "logo.png", size: 245 %><br>
+      <%= attachment_image_tag @product, :image, format: 'jpg', fallback: "logo.png", size: 245 %><br>
     </div>
         <div class="col-xs-8 ">
             <div>
@@ -11,9 +11,9 @@
                 <h2>¥<%= @product.price %>（税込み）</h2><br>
             </div>
             <%= form_for(@cart_product, url: cart_products_path) do |f| %> <%# ここにurlをいれるandカートプロダクトコントローラのcreateアクションをいじる %>
-             <%= f.hidden_field :product_id, value: @product.id %> <%# フォームの見た目上quantityしか渡せないが、hiddenを使うとViewに表示させずに他の値を渡せる。今回は何の何の商品が何個(quantity)欲しいかを教えてあげたいので、product_idカラムに入る@product.idと言う値を追加している。@product.idは↑の３つ。すなわちproductモデルのPK %>
-             <%= f.number_field :quantity, placeholder: "個数選択",class: 'btn btn-default'  %> <%# "個数選択"と、薄く表記がされる数値以外を受け付けないフォーム生成 %>
-             <%= f.submit 'カートにいれる',class: 'btn btn-primary' %>
+              <%= f.hidden_field :product_id, value: @product.id %> <%# フォームの見た目上quantityしか渡せないが、hiddenを使うとViewに表示させずに他の値を渡せる。今回は何の何の商品が何個(quantity)欲しいかを教えてあげたいので、product_idカラムに入る@product.idと言う値を追加している。@product.idは↑の３つ。すなわちproductモデルのPK %>
+              <%= f.number_field :quantity, placeholder: "個数選択",class: 'btn btn-default'  %> <%# "個数選択"と、薄く表記がされる数値以外を受け付けないフォーム生成 %>
+              <%= f.submit 'カートにいれる',class: 'btn btn-primary' %>
             <% end %>
         </div>
   </div>

--- a/app/views/public/users/top.html.erb
+++ b/app/views/public/users/top.html.erb
@@ -24,7 +24,7 @@
                         <%# 5/9 link_toにstyleを追加し文字色を黒に統一 %>
                         <%= link_to product_path(p.id), :style=>"color:black" do %>
                         <%# 5/10 "p.image"の"image"を削除,fillを400,formatを'jpeg'に変更 %>
-                            <%= attachment_image_tag p, :image, :fill, 400, 400, format: 'jpg', class: "pull-left profile-img", fallback: "logo.png", size:'100x100' %>
+                            <%= attachment_image_tag p, :image, format: 'jpg', class: "pull-left profile-img", fallback: "logo.png", size:'100x100' %>
                             <br>
                             <%= p.name %><br>
                         <% end %>


### PR DESCRIPTION
僕のPCではattachment_image_tagにfillを入れると画像がうまく表示されないので、fillの記述を削除しました。