### PR TITLE
【とし】close #158、#157、#146の修正

### DIFF
--- a/app/views/public/products/show.html.erb
+++ b/app/views/public/products/show.html.erb
@@ -8,13 +8,20 @@
             <div>
                 <h1><%= @product.name %></h1><br>
                 <h3><%= @product.introduction %></h3><br>
-                <h2>¥<%= @product.price %>（税込み）</h2><br>
+                <% if @product.validation == true %>
+                  <h2>¥<%= (@product.price*1.1).round %>（税込み）</h2><br>
+                <% else %>
+                  <h2>soldout</h2><br>
+                <% end %>
             </div>
             <%= form_for(@cart_product, url: cart_products_path) do |f| %> <%# ここにurlをいれるandカートプロダクトコントローラのcreateアクションをいじる %>
               <%= f.hidden_field :product_id, value: @product.id %> <%# フォームの見た目上quantityしか渡せないが、hiddenを使うとViewに表示させずに他の値を渡せる。今回は何の何の商品が何個(quantity)欲しいかを教えてあげたいので、product_idカラムに入る@product.idと言う値を追加している。@product.idは↑の３つ。すなわちproductモデルのPK %>
-              <%= f.number_field :quantity, placeholder: "個数選択",class: 'btn btn-default'  %> <%# "個数選択"と、薄く表記がされる数値以外を受け付けないフォーム生成 %>
-              <%= f.submit 'カートにいれる',class: 'btn btn-primary' %>
+               <% if @product.validation == true %>
+                <%= f.number_field :quantity, placeholder: "個数選択",class: 'btn btn-default',min: 1 %> <%# "個数選択"と、薄く表記がされる数値以外を受け付けないフォーム生成,min:0とmax:100で最小値と最大値の設定%>
+                <%= f.submit 'カートにいれる',class: 'btn btn-primary' %>
+               <% end %>
             <% end %>
         </div>
   </div>
 </div>
+

--- a/app/views/public/products/show.html.erb
+++ b/app/views/public/products/show.html.erb
@@ -9,17 +9,17 @@
                 <h1><%= @product.name %></h1><br>
                 <h3><%= @product.introduction %></h3><br>
                 <% if @product.validation == true %>
-                  <h2>¥<%= (@product.price*1.1).round %>（税込み）</h2><br>
+                  <h2>¥<%= money_notation(@product.price*1.1) %>（税込み）</h2><br>
                 <% else %>
                   <h2>soldout</h2><br>
                 <% end %>
             </div>
-            <%= form_for(@cart_product, url: cart_products_path) do |f| %> <%# ここにurlをいれるandカートプロダクトコントローラのcreateアクションをいじる %>
-              <%= f.hidden_field :product_id, value: @product.id %> <%# フォームの見た目上quantityしか渡せないが、hiddenを使うとViewに表示させずに他の値を渡せる。今回は何の何の商品が何個(quantity)欲しいかを教えてあげたいので、product_idカラムに入る@product.idと言う値を追加している。@product.idは↑の３つ。すなわちproductモデルのPK %>
-               <% if @product.validation == true %>
+            <% if @product.validation == true %>
+              <%= form_for(@cart_product, url: cart_products_path) do |f| %> <%# ここにurlをいれるandカートプロダクトコントローラのcreateアクションをいじる %>
+                <%= f.hidden_field :product_id, value: @product.id %> <%# フォームの見た目上quantityしか渡せないが、hiddenを使うとViewに表示させずに他の値を渡せる。今回は何の何の商品が何個(quantity)欲しいかを教えてあげたいので、product_idカラムに入る@product.idと言う値を追加している。@product.idは↑の３つ。すなわちproductモデルのPK %>
                 <%= f.number_field :quantity, placeholder: "個数選択",class: 'btn btn-default',min: 1 %> <%# "個数選択"と、薄く表記がされる数値以外を受け付けないフォーム生成,min:0とmax:100で最小値と最大値の設定%>
                 <%= f.submit 'カートにいれる',class: 'btn btn-primary' %>
-               <% end %>
+              <% end %>
             <% end %>
         </div>
   </div>


### PR DESCRIPTION
・#158 商品詳細の料金表示を税込価格に&売り切れの場合は「売り切れ」の文字に
・#157 ステータスが「売り切れ」の商品をカートに入れられないようにする
・#146 ECサイト商品詳細の個数選択がマイナスも選べてしまう
を、それぞれ修正