### PR TITLE
close #82【とし】会員トップページ　画像の横に商品名・料金が表示されてしまう問題の解消

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -39,3 +39,19 @@
 .field_with_errors {
   display: contents;
 }
+
+.image {
+  display:block;
+  width: 100px;
+  height: 100px;
+  margin: 0 auto;
+}
+
+.cakes {
+  text-align: center;
+  display:block;
+}
+
+.nextview {
+  text-align:right;
+}

--- a/app/views/layouts/_search_side_bar.html.erb
+++ b/app/views/layouts/_search_side_bar.html.erb
@@ -7,7 +7,7 @@
   <tbody>
     <% genres.each do |genre| %>
       <tr>
-        <td><%= link_to genre.name, search_products_path(genre_name: "#{genre.name}"), method: :post %></td>
+        <td><%= link_to genre.name, search_products_path(genre_name: "#{genre.name}"), method: :post, :style=>"color:black" %></td>
       </tr>
     <% end %>
   </tbody>

--- a/app/views/public/users/top.html.erb
+++ b/app/views/public/users/top.html.erb
@@ -21,22 +21,23 @@
 
             <div class="row">
 
-                <% @products.each do |p| %>
-                    <div class="col-xs-3">
+                <% @products.shuffle.first(4).each do |p| %>
+                        <div class="col-xs-3 cakes">
                                 <%# 5/9 link_toにstyleを追加し文字色を黒に統一 %>
                                 <%= link_to product_path(p.id), :style=>"color:black" do %>
                                 <%# 5/10 "p.image"の"image"を削除,fillを400,formatを'jpeg'に変更 %>
-                                    <%= attachment_image_tag p, :image, format: 'jpg', class: "pull-left profile-img", fallback: "logo.png", size:'100x100' %>
-                                    <br>
-                                    <%= p.name %><br>
+                                    <div class="image">
+                                      <%= attachment_image_tag p, :image, format: 'jpg', class: "pull-left profile-img" "img-responsive", fallback: "logo.png", size:'100x100' %><br>
+                                    </div>
+                                    <p><%= p.name %></p>
+                                    <p>¥<%= p.price %></p>
                                 <% end %>
-                                ¥<%= p.price %>
-                    </div>
+                        </div>
                 <% end %>
 
             </div>
 
-            <div class="row">
+            <div class="row nextview">
                 <%# 5/9 link_toにstyleを追加し文字色を黒に統一 %>
                 <%= link_to "もっと見る", products_path, :style=>"color:black" %>
             </div>


### PR DESCRIPTION
top画面のレイアウト変更しました。
・「もっと見る」を右寄せに修正
・商品画像の下に商品名と金額がくるように修正
(・いっとうさん作のサイドバーの文字色を黒に調整)
