### PR TITLE
【一刀】郵便番号、電話番号の桁数についてのバリデーションを修正

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -20,8 +20,8 @@ class User < ApplicationRecord
     u.validates :phone_number
   end
 
-  validates :postal_code, format: { with: /\d{7}/} #日本の郵便番号は必ず7桁らしいです。
-  validates :phone_number, format: { with: /\d{10,11}/} #日本の電話番号は必ず10か11桁らしいです。
+  validates :postal_code, format: { with: /\A\d{7}\z/} #日本の郵便番号は必ず7桁らしいです。
+  validates :phone_number, format: { with: /\A\d{10,11}\z/} #日本の電話番号は必ず10か11桁らしいです。
 
 	#boolean型はpresence: trueにしてしまうと、falseを空だと認識して弾かれてしまうので以下のように記述。
   validates :validation, inclusion:{in: [true, false]}


### PR DESCRIPTION
\A, \zを追記し、「文字の始めから終わりまで○桁の数字のみ」というバリデーションに修正。
(今までのは○桁の数字をどこかに含む、という意味になってしまっていました。)